### PR TITLE
fix(assets): fixing hashed assets mapping

### DIFF
--- a/assets/fingerprint.go
+++ b/assets/fingerprint.go
@@ -44,17 +44,14 @@ func (m *manager) PathFor(fname string) (string, error) {
 	hashString := hex.EncodeToString(hash[:])
 
 	// Add the hash to the filename
-	filename := path.Base(normalized)
 	ext := path.Ext(normalized)
-	newFilename := filename[:len(filename)-len(ext)] + "-" + hashString + ext
+	filename := strings.TrimSuffix(normalized, ext)
+	filename += "-" + hashString + ext
 
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
-	m.fileToHash[normalized] = newFilename
-	m.HashToFile[newFilename] = normalized
+	m.fileToHash[normalized] = filename
+	m.HashToFile[filename] = normalized
 
-	result = path.Join(path.Dir(normalized), newFilename)
-	result = withPrefix(result)
-
-	return result, nil
+	return withPrefix(filename), nil
 }

--- a/assets/fingerprint_test.go
+++ b/assets/fingerprint_test.go
@@ -24,6 +24,16 @@ func TestFingerprint(t *testing.T) {
 		if !strings.Contains(a, "/public/") {
 			t.Errorf("Expected %s to have /public/ prefix", a)
 		}
+
+		a, _ = m.PathFor("public/other/main.js")
+		b, _ = m.PathFor("public/other/main.js")
+		if a != b {
+			t.Errorf("Expected %s to equal %s", a, b)
+		}
+
+		if !strings.Contains(a, "/public/") {
+			t.Errorf("Expected %s to have /public/ prefix", a)
+		}
 	})
 
 	t.Run("adds starting slash", func(t *testing.T) {
@@ -51,9 +61,13 @@ func TestFingerprint(t *testing.T) {
 	})
 
 	t.Run("respects folders", func(t *testing.T) {
-		a, err := m.PathFor("public/main.js")
+		a, err := m.PathFor("main.js")
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		if !strings.HasPrefix(a, "/public/main-") {
+			t.Errorf("Expected %s to contain /public/other/main-<hash>", a)
 		}
 
 		b, _ := m.PathFor("public/other/main.js")
@@ -61,8 +75,19 @@ func TestFingerprint(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if !strings.HasPrefix(b, "/public/other/main-") {
+			t.Errorf("Expected %s to contain /public/other/main-<hash>", b)
+		}
+
 		if a == b {
 			t.Errorf("Expected %s to not equal %s", a, b)
+		}
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		a, err := m.PathFor("foo.js")
+		if err == nil {
+			t.Errorf("File must not exists: %s", a)
 		}
 	})
 }


### PR DESCRIPTION
This PR fixes the assets `PathFor` function by adjusting the `fileToHash` and `HashToFile` mapping using the normalized file path which contains the relative path instead of using only the filename.