### PR TITLE
fix: allowing multi-lines in env variables - envload

### DIFF
--- a/tools/envload/envload.go
+++ b/tools/envload/envload.go
@@ -33,28 +33,65 @@ func init() {
 func parseVars(r io.Reader) map[string]string {
 	vars := make(map[string]string)
 	scanner := bufio.NewScanner(r)
+	var key, value string
+	var isMultiLine bool
+
 	for scanner.Scan() {
 		line := scanner.Text()
-		if line == "" {
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		// Comments
-		if strings.HasPrefix(line, "#") {
-			continue
+		switch {
+		case !isMultiLine:
+			key, value, isMultiLine = parseLine(line)
+		default:
+			value, isMultiLine = continueMultiLineValue(value, line)
 		}
-
-		pair := strings.SplitN(line, "=", 2)
-		if len(pair) != 2 {
-			continue
-		}
-
-		key := strings.TrimSpace(pair[0])
-		value := strings.TrimSpace(pair[1])
-		value = strings.Trim(value, "\"")
 
 		vars[key] = value
 	}
 
 	return vars
+}
+
+// parseLine parses a line from the .env file and returns the key and value
+// and if the value is a multi-line value
+// It returns the key, value and a boolean indicating if the value is a multi-line value
+func parseLine(line string) (key, value string, isMultiLine bool) {
+	pair := strings.SplitN(line, "=", 2)
+	if len(pair) != 2 {
+		return
+	}
+
+	key = strings.TrimSpace(pair[0])
+	value = strings.TrimSpace(pair[1])
+
+	// Check if the value is a multi-line value by checking if it starts with a quote but doesn't end with one
+	if strings.HasPrefix(value, "\"") && !strings.HasSuffix(value, "\"") {
+		isMultiLine = true
+		value = value[1:] + "\n"
+		return
+	}
+
+	// Check if the value is a multi-line value by checking if it starts and ends with a quote on the same line
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		value = value[1 : len(value)-1]
+	}
+
+	return key, value, isMultiLine
+}
+
+// continueMultiLineValue continues a multi-line value
+// by appending the line to the value until the line ends with a quote
+func continueMultiLineValue(value, line string) (string, bool) {
+	value += line + "\n"
+	if strings.HasSuffix(line, "\"") {
+		return value[:len(value)-2], false
+	}
+
+	return value, true
+
 }

--- a/tools/envload/envload_test.go
+++ b/tools/envload/envload_test.go
@@ -1,6 +1,7 @@
 package envload
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -48,6 +49,48 @@ func TestParseVars(t *testing.T) {
 
 		if vars["KEY"] != "value=with=equals" {
 			t.Errorf("Expected value to be 'value=with=equals', got %s", vars["KEY"])
+		}
+	})
+
+	t.Run("multiple lines", func(t *testing.T) {
+		value := `-----BEGIN RSA PRIVATE KEY-----
+		MIIEpAIBAAKCAQEAqTmwQppL07nBl/0TEQ5sHcqj/Iz9BmuaaEu26jMXYt1QttHn
+		-----END RSA PRIVATE KEY-----`
+
+		vars := parseVars(strings.NewReader(fmt.Sprintf(`
+		KEY="%s"`, value)))
+
+		if vars["KEY"] != value {
+			t.Errorf("Expected value to be %s', got %s", value, vars["KEY"])
+		}
+	})
+
+	t.Run("comments", func(t *testing.T) {
+		vars := parseVars(strings.NewReader(`
+			# This is a comment
+			KEY=value
+		`))
+
+		if vars["KEY"] != "value" {
+			t.Errorf("Expected value to be 'value', got %s", vars["KEY"])
+		}
+	})
+
+	t.Run("multiple lines with another variable", func(t *testing.T) {
+		value := `-----BEGIN RSA PRIVATE KEY-----
+		MIIEpAIBAAKCAQEAqTmwQppL07nBl/0TEQ5sHcqj/Iz9BmuaaEu26jMXYt1QttHn
+		-----END RSA PRIVATE KEY-----`
+
+		vars := parseVars(strings.NewReader(fmt.Sprintf(`
+		KEY="%s"
+		KEY2=value`, value)))
+
+		if vars["KEY"] != value {
+			t.Errorf("Expected value to be %s', got %s", value, vars["KEY"])
+		}
+
+		if vars["KEY2"] != "value" {
+			t.Errorf("Expected value to be 'value', got %s", vars["KEY2"])
 		}
 	})
 


### PR DESCRIPTION
## Description ##
This PR is to fix the issue when trying to add variable with multiple lines as a value

Now, it allows doing something like this:

```.env
KEY="ValueValue
VALUEVALUE
VALUE"
```

and also adding more variables with no problem

```.env
KEY="ValueValue
VALUEVALUE
VALUE"
KEY2="NEWVALUE"
```