### PR TITLE
Envload: adding multi-lines doc

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,7 +10,7 @@ To get started with LeapKit the [template](https://github.com/leapkit/template) 
 To generate your project you can use `gonew` to copy the template and generate the necessary files for your project. The following command will generate a new project called `superapp` in the current directory.
 
 ```
-go run rsc.io/tmp/gonew@latest github.com/leapkit/template@v1.1.5 superapp
+go run rsc.io/tmp/gonew@latest github.com/leapkit/template@v1.1.8 superapp
 ```
 
 ### Setup

--- a/docs/tools/environment.md
+++ b/docs/tools/environment.md
@@ -26,7 +26,7 @@ PORT=8080
 Leapkit supports multi-line values by using the quoted string syntax:
 
 ```.env
-KEY="-----BEGIN RSA PRIVATE KEY-----
+GITHUB_SECRET_KEY="-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAqTmwQppL07nBl/0TEQ5sHcqj/Iz9BmuaaEu26jMXYt1QttHn
 -----END RSA PRIVATE KEY-----"
 ```

--- a/docs/tools/environment.md
+++ b/docs/tools/environment.md
@@ -5,14 +5,34 @@ index: 2
 
 Leapkit provides a handy tool to load environment variables from a `.env` file. This feature is useful when you want to load your environment variables from a file instead of setting them directly in your system, like when you're in development mode.
 
+### Creating a `.env` file
+
 To use it you can create a `.env` file in the root of your project and add your environment variables in the following format:
 
-```env
+```.env
 # .env
 PORT=8080
 ```
 
-Then, you can load the environment variables in your by doing an underscore import on your `main.go` file.
+### Adding Comments
+You can also add comments to your `.env` file by starting the line with a `#` character.
+```.env
+# .env
+# This is a comment
+PORT=8080
+```
+### Multi-line values
+
+Leapkit supports multi-line values by using the quoted string syntax:
+
+```.env
+KEY="-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAqTmwQppL07nBl/0TEQ5sHcqj/Iz9BmuaaEu26jMXYt1QttHn
+-----END RSA PRIVATE KEY-----"
+```
+
+## Loading the environment variables
+To load the environment variables from the .env file into your application, perform an underscore import in your main.go file:
 
 ```go
 // main.go


### PR DESCRIPTION
## Description ##
Improve the documentation for loading environment variables from a `.env` file. Add instructions for creating the file, adding comments, and using multi-line values. Also, update the code example for loading the environment variables.