### PR TITLE
feat(server): allowing to clear middleware

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -7,11 +7,13 @@ import (
 	"time"
 )
 
+// baseMiddleware is a list that holds the middleware list that will be executed
+// at the beginning of a client request.
 var baseMiddleware = []Middleware{
-	logger,
-	recoverer,
-	requestID,
 	setValuer,
+	requestID,
+	recoverer,
+	logger,
 }
 
 // Middleware is a function that receives a http.Handler and returns a http.Handler

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+var baseMiddleware = []Middleware{
+	logger,
+	recoverer,
+	requestID,
+	setValuer,
+}
+
 // Middleware is a function that receives a http.Handler and returns a http.Handler
 // that can be used to wrap the original handler with some functionality.
 type Middleware func(http.Handler) http.Handler

--- a/server/mux.go
+++ b/server/mux.go
@@ -18,15 +18,10 @@ type mux struct {
 func New(options ...Option) *mux {
 	ss := &mux{
 		router: &router{
-			prefix: "",
-			mux:    http.NewServeMux(),
-			baseMiddleware: []Middleware{
-				logger,
-				recoverer,
-				requestID,
-				setValuer,
-			},
-			middleware: []Middleware{},
+			prefix:         "",
+			mux:            http.NewServeMux(),
+			baseMiddleware: baseMiddleware,
+			middleware:     []Middleware{},
 		},
 
 		host: "0.0.0.0",

--- a/server/mux.go
+++ b/server/mux.go
@@ -20,7 +20,7 @@ func New(options ...Option) *mux {
 		router: &router{
 			prefix:     "",
 			mux:        http.NewServeMux(),
-			middleware: []Middleware{},
+			middleware: baseMiddleware,
 		},
 
 		host: "0.0.0.0",

--- a/server/mux.go
+++ b/server/mux.go
@@ -18,19 +18,20 @@ type mux struct {
 func New(options ...Option) *mux {
 	ss := &mux{
 		router: &router{
-			prefix:     "",
-			mux:        http.NewServeMux(),
+			prefix: "",
+			mux:    http.NewServeMux(),
+			baseMiddleware: []Middleware{
+				logger,
+				recoverer,
+				requestID,
+				setValuer,
+			},
 			middleware: []Middleware{},
 		},
 
 		host: "0.0.0.0",
 		port: "3000",
 	}
-
-	ss.Use(logger)
-	ss.Use(recoverer)
-	ss.Use(requestID)
-	ss.Use(setValuer)
 
 	for _, option := range options {
 		option(ss)

--- a/server/mux.go
+++ b/server/mux.go
@@ -18,10 +18,9 @@ type mux struct {
 func New(options ...Option) *mux {
 	ss := &mux{
 		router: &router{
-			prefix:         "",
-			mux:            http.NewServeMux(),
-			baseMiddleware: baseMiddleware,
-			middleware:     []Middleware{},
+			prefix:     "",
+			mux:        http.NewServeMux(),
+			middleware: []Middleware{},
 		},
 
 		host: "0.0.0.0",

--- a/server/router.go
+++ b/server/router.go
@@ -14,8 +14,8 @@ type Router interface {
 	// Use allows to specify a middleware that should be executed for all the handlers
 	Use(middleware ...Middleware)
 
-	// ClearMiddleware removes the middleware list from the router.
-	ClearMiddleware()
+	// ResetMiddleware clears the list of middleware on the router by setting the baseMiddleware.
+	ResetMiddleware()
 
 	// Handle allows to register a new handler for a specific pattern
 	Handle(pattern string, handler http.Handler)
@@ -46,19 +46,15 @@ func (rg *router) Use(middleware ...Middleware) {
 	rg.middleware = append(middleware, rg.middleware...)
 }
 
-// ClearMiddleware removes the middleware list from the router.
-func (rg *router) ClearMiddleware() {
-	rg.middleware = []Middleware{}
+// ResetMiddleware clears the list of middleware on the router by setting the baseMiddleware.
+func (rg *router) ResetMiddleware() {
+	rg.middleware = baseMiddleware
 }
 
 // Handle allows to register a new handler for a specific pattern
 // in the group with the middleware that should be executed for the handler
 // specified in the group.
 func (rg *router) Handle(pattern string, handler http.Handler) {
-	for _, v := range baseMiddleware {
-		handler = v(handler)
-	}
-
 	for _, v := range rg.middleware {
 		handler = v(handler)
 	}

--- a/server/router.go
+++ b/server/router.go
@@ -95,9 +95,10 @@ func (rg *router) Folder(prefix string, fs fs.FS) {
 // and middleware that should be executed for all the handlers in the group
 func (rg *router) Group(prefix string, rfn func(rg Router)) {
 	group := &router{
-		prefix:     path.Join(rg.prefix, prefix),
-		mux:        rg.mux,
-		middleware: rg.middleware,
+		prefix:         path.Join(rg.prefix, prefix),
+		mux:            rg.mux,
+		baseMiddleware: rg.baseMiddleware,
+		middleware:     rg.middleware,
 	}
 
 	rfn(group)

--- a/server/router.go
+++ b/server/router.go
@@ -33,10 +33,9 @@ type Router interface {
 // router is a group of routes with a common prefix and middleware
 // that should be executed for all the handlers in the group
 type router struct {
-	prefix         string
-	mux            *http.ServeMux
-	baseMiddleware []Middleware
-	middleware     []Middleware
+	prefix     string
+	mux        *http.ServeMux
+	middleware []Middleware
 }
 
 // Use allows to specify a middleware that should be executed for all the handlers
@@ -56,7 +55,7 @@ func (rg *router) ClearMiddleware() {
 // in the group with the middleware that should be executed for the handler
 // specified in the group.
 func (rg *router) Handle(pattern string, handler http.Handler) {
-	for _, v := range rg.baseMiddleware {
+	for _, v := range baseMiddleware {
 		handler = v(handler)
 	}
 
@@ -95,10 +94,9 @@ func (rg *router) Folder(prefix string, fs fs.FS) {
 // and middleware that should be executed for all the handlers in the group
 func (rg *router) Group(prefix string, rfn func(rg Router)) {
 	group := &router{
-		prefix:         path.Join(rg.prefix, prefix),
-		mux:            rg.mux,
-		baseMiddleware: rg.baseMiddleware,
-		middleware:     rg.middleware,
+		prefix:     path.Join(rg.prefix, prefix),
+		mux:        rg.mux,
+		middleware: rg.middleware,
 	}
 
 	rfn(group)

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -87,7 +87,7 @@ func TestMiddleware(t *testing.T) {
 		})
 
 		r.Group("/without", func(r server.Router) {
-			r.ClearMiddleware()
+			r.ResetMiddleware()
 
 			r.HandleFunc("GET /mw/{$}", func(w http.ResponseWriter, r *http.Request) {
 				v, ok := r.Context().Value("customValue").(string)
@@ -114,7 +114,7 @@ func TestMiddleware(t *testing.T) {
 	}{
 		{"request to handler with middleware", "/mw/", "Hello, World!"},
 		{"request to handler without middleware", "/without/mw/", "customValue not found"},
-		{"request to handler with middleware", "/other-with/mw/", "Hello, World! (again)"},
+		{"request to other handler with middleware", "/other-with/mw/", "Hello, World! (again)"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This MR adds the new `ClearMiddleware` router method that allows cleaning the router middleware list that is set in the router. This is useful when a router group should not inherit any middleware from its parent.