### PR TITLE
fix(assets): recalculate assets hashes in development mode

### DIFF
--- a/assets/fingerprint.go
+++ b/assets/fingerprint.go
@@ -40,6 +40,7 @@ func (m *manager) PathFor(name string) (string, error) {
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
 
+	// Delete previous asset hash from map
 	if old, exists := m.fileToHash[normalized]; exists && old != filename {
 		delete(m.HashToFile, old)
 	}

--- a/assets/manager.go
+++ b/assets/manager.go
@@ -24,12 +24,11 @@ func NewManager(embedded fs.FS, servingPath string) *manager {
 		servingPath = "/"
 	}
 
-	if !strings.HasPrefix(servingPath, "/") {
-		servingPath = "/" + servingPath
-	}
-
-	if !strings.HasSuffix(servingPath, "/") {
-		servingPath += "/"
+	servingPath = strings.Trim(servingPath, "/")
+	if servingPath == "" {
+		servingPath = "/"
+	} else {
+		servingPath = "/" + servingPath + "/"
 	}
 
 	return &manager{


### PR DESCRIPTION
This PR makes the assets' manager to recalculate asset hashes when `GO_ENV=development`.
For other envs, asset hashes will be calculate only the first time.