### PR TITLE
task(assets): fingerprint all importmap scopes

### DIFF
--- a/assets/fingerprint_test.go
+++ b/assets/fingerprint_test.go
@@ -427,15 +427,15 @@ func TestImportMap(t *testing.T) {
 	t.Run("valid importmap.json without application", func(t *testing.T) {
 		importMapJSON := `{
 			"imports": {
-				"react": "/assets/react.js",
-				"vue": "/assets/vue.js"
+				"lib-a": "/assets/lib-a.js",
+				"lib-b": "/assets/lib-b.js"
 			}
 		}`
 
 		m := assets.NewManager(fstest.MapFS{
 			"importmap.json": {Data: []byte(importMapJSON)},
-			"react.js":       {Data: []byte("// React code")},
-			"vue.js":         {Data: []byte("// Vue code")},
+			"lib-a.js":       {Data: []byte("// Lib A code")},
+			"lib-b.js":       {Data: []byte("// Lib B code")},
 		}, "/assets")
 
 		result, err := m.ImportMap()
@@ -447,11 +447,11 @@ func TestImportMap(t *testing.T) {
 		if !strings.Contains(resultStr, `<script type="importmap">`) {
 			t.Error("Expected importmap script tag")
 		}
-		if !strings.Contains(resultStr, "react") {
-			t.Error("Expected react import")
+		if !strings.Contains(resultStr, "lib-a") {
+			t.Error("Expected lib-a import")
 		}
-		if !strings.Contains(resultStr, "vue") {
-			t.Error("Expected vue import")
+		if !strings.Contains(resultStr, "lib-b") {
+			t.Error("Expected lib-b import")
 		}
 		if strings.Contains(resultStr, `<script type="module">import "application";</script>`) {
 			t.Error("Should not contain application import when not present")
@@ -462,14 +462,14 @@ func TestImportMap(t *testing.T) {
 		importMapJSON := `{
 			"imports": {
 				"application": "/assets/application.js",
-				"react": "/assets/react.js"
+				"lib-a": "/assets/lib-a.js"
 			}
 		}`
 
 		m := assets.NewManager(fstest.MapFS{
 			"importmap.json": {Data: []byte(importMapJSON)},
 			"application.js": {Data: []byte("// Application code")},
-			"react.js":       {Data: []byte("// React code")},
+			"lib-a.js":       {Data: []byte("// Lib A code")},
 		}, "/assets")
 
 		result, err := m.ImportMap()
@@ -604,6 +604,497 @@ func TestImportMap(t *testing.T) {
 		}
 		if !strings.Contains(resultStr, `"imports": {}`) {
 			t.Error("Expected empty imports object")
+		}
+	})
+}
+
+func TestImportMapWithScopes(t *testing.T) {
+	t.Run("importmap with scopes fingerprints all paths", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"@org/package-main": "vendor/@org/package-main@1.2.0/dist/index.js"
+			},
+			"scopes": {
+				"vendor/@org/package-main@1.2.0/": {
+					"@org/package-dep/utils": "vendor/@org/package-dep@2.3.0/dist/utils/index.js",
+					"package-helper": "vendor/package-helper@3.1.0/dist/index.js"
+				}
+			}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                          {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.2.0/dist/index.js":           {Data: []byte("// Main package")},
+			"vendor/@org/package-dep@2.3.0/dist/utils/index.js":      {Data: []byte("// Dep utils")},
+			"vendor/package-helper@3.1.0/dist/index.js":              {Data: []byte("// Helper")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		resultStr := string(result)
+		
+		// Check basic structure
+		if !strings.Contains(resultStr, `<script type="importmap">`) {
+			t.Error("Expected importmap script tag")
+		}
+		
+		// Check that imports are present
+		if !strings.Contains(resultStr, "@org/package-main") {
+			t.Error("Expected @org/package-main in imports")
+		}
+		
+		// Check that scopes field is present
+		if !strings.Contains(resultStr, "scopes") {
+			t.Error("Expected scopes field in output")
+		}
+		
+		// CRITICAL: Scope keys must include serving path prefix
+		if !strings.Contains(resultStr, `"/assets/vendor/@org/package-main@1.2.0/"`) {
+			t.Errorf("Expected scope key with serving path '/assets/vendor/@org/package-main@1.2.0/', got: %s", resultStr)
+		}
+		
+		// Check that scope entries are present
+		if !strings.Contains(resultStr, "@org/package-dep/utils") {
+			t.Error("Expected @org/package-dep/utils in scopes")
+		}
+		if !strings.Contains(resultStr, "package-helper") {
+			t.Error("Expected package-helper in scopes")
+		}
+		
+		// Vendor files SHOULD be fingerprinted for cache busting
+		if !strings.Contains(resultStr, "/assets/vendor/@org/package-dep@2.3.0/dist/utils/index-") {
+			t.Errorf("Expected fingerprinted vendor path for @org/package-dep/utils, got: %s", resultStr)
+		}
+		
+		// Should contain hash
+		if !strings.Contains(resultStr, "index-") {
+			t.Errorf("Vendor files should be fingerprinted, got: %s", resultStr)
+		}
+	})
+
+	t.Run("scopes with missing files logs error but continues", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"@org/package-main": "vendor/@org/package-main@1.2.0/dist/index.js"
+			},
+			"scopes": {
+				"vendor/@org/package-main@1.2.0/": {
+					"existing": "vendor/existing@1.0.0/index.js",
+					"missing": "vendor/missing@1.0.0/index.js"
+				}
+			}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.2.0/dist/index.js": {Data: []byte("// Main package")},
+			"vendor/existing@1.0.0/index.js":               {Data: []byte("// Existing")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		resultStr := string(result)
+		
+		// Should still generate importmap even if some scope files are missing
+		if !strings.Contains(resultStr, `<script type="importmap">`) {
+			t.Error("Expected importmap script tag")
+		}
+		
+		// Should contain the existing scope entry
+		if !strings.Contains(resultStr, "existing") {
+			t.Error("Expected existing scope entry")
+		}
+	})
+
+	t.Run("importmap without scopes field works normally", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"lib-a": "/assets/lib-a.js"
+			}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json": {Data: []byte(importMapJSON)},
+			"lib-a.js":       {Data: []byte("// Lib A code")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		resultStr := string(result)
+		if !strings.Contains(resultStr, "lib-a") {
+			t.Error("Expected lib-a import")
+		}
+		
+		// Should not have scopes field when not in original JSON
+		// (This is implicit - just verifying it doesn't break)
+	})
+
+	t.Run("empty scopes map", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"lib-a": "/assets/lib-a.js"
+			},
+			"scopes": {}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json": {Data: []byte(importMapJSON)},
+			"lib-a.js":       {Data: []byte("// Lib A code")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		resultStr := string(result)
+		if !strings.Contains(resultStr, `<script type="importmap">`) {
+			t.Error("Expected importmap script tag")
+		}
+	})
+
+	t.Run("scope keys include serving path prefix", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"@org/package-main": "vendor/@org/package-main@1.2.0/dist/index.js"
+			},
+			"scopes": {
+				"vendor/@org/package-main@1.2.0/": {
+					"package-helper": "vendor/package-helper@3.1.0/dist/index.js"
+				}
+			}
+		}`
+
+		// Test with /assets serving path
+		m1 := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.2.0/dist/index.js":     {Data: []byte("// Main package")},
+			"vendor/package-helper@3.1.0/dist/index.js": {Data: []byte("// Helper")},
+		}, "/assets")
+
+		result1, err := m1.ImportMap()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resultStr1 := string(result1)
+		if !strings.Contains(resultStr1, `"/assets/vendor/@org/package-main@1.2.0/"`) {
+			t.Errorf("Expected scope key '/assets/vendor/@org/package-main@1.2.0/', got: %s", resultStr1)
+		}
+
+		// Test with /public serving path
+		m2 := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.2.0/dist/index.js":     {Data: []byte("// Main package")},
+			"vendor/package-helper@3.1.0/dist/index.js": {Data: []byte("// Helper")},
+		}, "/public")
+
+		result2, err := m2.ImportMap()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resultStr2 := string(result2)
+		if !strings.Contains(resultStr2, `"/public/vendor/@org/package-main@1.2.0/"`) {
+			t.Errorf("Expected scope key '/public/vendor/@org/package-main@1.2.0/', got: %s", resultStr2)
+		}
+
+		// Test with root / serving path
+		m3 := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.2.0/dist/index.js":     {Data: []byte("// Main package")},
+			"vendor/package-helper@3.1.0/dist/index.js": {Data: []byte("// Helper")},
+		}, "/")
+
+		result3, err := m3.ImportMap()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resultStr3 := string(result3)
+		if !strings.Contains(resultStr3, `"/vendor/@org/package-main@1.2.0/"`) {
+			t.Errorf("Expected scope key '/vendor/@org/package-main@1.2.0/', got: %s", resultStr3)
+		}
+	})
+
+	t.Run("scopes paths are always fingerprinted", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"@org/package-main": "vendor/@org/package-main@1.2.0/dist/index.js"
+			},
+			"scopes": {
+				"vendor/@org/package-main@1.2.0/": {
+					"logo": "vendor/logo.svg"
+				}
+			}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json":                               {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.2.0/dist/index.js": {Data: []byte("// Main package")},
+			"vendor/logo.svg":                              {Data: []byte("<svg></svg>")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		resultStr := string(result)
+
+		// Every asset, including SVG, must be fingerprinted.
+		if !strings.Contains(resultStr, "/assets/vendor/logo-") {
+			t.Errorf("Expected fingerprinted SVG path, got: %s", resultStr)
+		}
+	})
+}
+
+func TestVendorFilesHashed(t *testing.T) {
+	t.Run("vendor files are fingerprinted for cache busting", func(t *testing.T) {
+		m := assets.NewManager(fstest.MapFS{
+			"vendor/@org/package-main@1.5.0/dist/index.js": {Data: []byte("// Main package")},
+			"vendor/lib-a@4.0.0/index.js":                   {Data: []byte("// Lib A")},
+			"app/main.js":                                   {Data: []byte("// App")},
+		}, "/assets")
+
+		// Vendor files SHOULD be hashed
+		vendorPath1, err := m.PathFor("vendor/@org/package-main@1.5.0/dist/index.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(vendorPath1, "index-") {
+			t.Errorf("Expected vendor file to be fingerprinted, got %s", vendorPath1)
+		}
+		if !strings.Contains(vendorPath1, "/vendor/@org/package-main@1.5.0/dist/") {
+			t.Errorf("Expected vendor path structure preserved, got %s", vendorPath1)
+		}
+
+		vendorPath2, err := m.PathFor("vendor/lib-a@4.0.0/index.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(vendorPath2, "index-") {
+			t.Errorf("Expected vendor file to be fingerprinted, got %s", vendorPath2)
+		}
+
+		// Non-vendor files should also be hashed
+		appPath, err := m.PathFor("app/main.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(appPath, "main-") {
+			t.Errorf("Expected app file to be fingerprinted, got %s", appPath)
+		}
+	})
+
+	t.Run("all asset types including svg are hashed", func(t *testing.T) {
+		m := assets.NewManager(fstest.MapFS{
+			"vendor/lib.js": {Data: []byte("LIB")},
+			"logo.svg":      {Data: []byte("SVG")},
+			"main.js":       {Data: []byte("MAIN")},
+		}, "/assets")
+
+		vendorPath, err := m.PathFor("vendor/lib.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(vendorPath, "/vendor/lib-") {
+			t.Errorf("Expected vendor file to be fingerprinted, got %s", vendorPath)
+		}
+
+		svgPath, err := m.PathFor("logo.svg")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(svgPath, "/logo-") {
+			t.Errorf("Expected SVG to be fingerprinted, got %s", svgPath)
+		}
+
+		mainPath, err := m.PathFor("main.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(mainPath, "main-") {
+			t.Errorf("Expected main.js to be fingerprinted, got %s", mainPath)
+		}
+	})
+
+	t.Run("importmap vendor files are hashed", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"@org/package-main": "vendor/@org/package-main@1.5.0/dist/index.js"
+			},
+			"scopes": {
+				"vendor/@org/package-main@1.5.0/": {
+					"package-helper": "vendor/package-helper@3.1.0/dist/index.js"
+				}
+			}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                    {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.5.0/dist/index.js":     {Data: []byte("// Main package")},
+			"vendor/package-helper@3.1.0/dist/index.js":        {Data: []byte("// Helper")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		resultStr := string(result)
+
+		// Vendor files SHOULD have hashes
+		if !strings.Contains(resultStr, "index-") {
+			t.Errorf("Vendor files should be fingerprinted in importmap, got: %s", resultStr)
+		}
+
+		// Should contain the fingerprinted vendor paths with serving path prefix
+		if !strings.Contains(resultStr, "/assets/vendor/@org/package-main@1.5.0/dist/index-") {
+			t.Errorf("Expected fingerprinted vendor path in importmap, got: %s", resultStr)
+		}
+		if !strings.Contains(resultStr, "/assets/vendor/package-helper@3.1.0/dist/index-") {
+			t.Errorf("Expected fingerprinted vendor path in scopes, got: %s", resultStr)
+		}
+	})
+
+	t.Run("vendor _/ files at organization level are hashed", func(t *testing.T) {
+		importMapJSON := `{
+			"imports": {
+				"@org/package-main": "vendor/@org/package-main@1.5.0/dist/index.js"
+			},
+			"scopes": {
+				"vendor/": {
+					"_/xyz789.js": "vendor/vendor/@org/_/xyz789.js"
+				}
+			}
+		}`
+
+		m := assets.NewManager(fstest.MapFS{
+			"importmap.json":                                {Data: []byte(importMapJSON)},
+			"vendor/@org/package-main@1.5.0/dist/index.js": {Data: []byte("// core")},
+			"vendor/vendor/@org/_/xyz789.js":                {Data: []byte("// helper")},
+		}, "/assets")
+
+		result, err := m.ImportMap()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		resultStr := string(result)
+
+		// Verify the _/ file is in the output
+		if !strings.Contains(resultStr, "_/xyz789.js") {
+			t.Errorf("Expected _/xyz789.js in output, got: %s", resultStr)
+		}
+
+		// Verify it has a hash in the path
+		if !strings.Contains(resultStr, "/assets/vendor/vendor/@org/_/xyz789-") {
+			t.Errorf("Expected fingerprinted path for _/xyz789.js, got: %s", resultStr)
+		}
+	})
+
+	t.Run("vendor files are hashed and respect serving path prefix", func(t *testing.T) {
+		// Test with /assets serving path
+		m1 := assets.NewManager(fstest.MapFS{
+			"vendor/@org/package-main@1.5.0/dist/index.js": {Data: []byte("// Main package")},
+		}, "/assets")
+
+		path1, err := m1.PathFor("vendor/@org/package-main@1.5.0/dist/index.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(path1, "/assets/vendor/@org/package-main@1.5.0/dist/index-") {
+			t.Errorf("Expected /assets prefix with hash, got %s", path1)
+		}
+
+		// Test with /static serving path
+		m2 := assets.NewManager(fstest.MapFS{
+			"vendor/@org/package-main@1.5.0/dist/index.js": {Data: []byte("// Main package")},
+		}, "/static")
+
+		path2, err := m2.PathFor("vendor/@org/package-main@1.5.0/dist/index.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(path2, "/static/vendor/@org/package-main@1.5.0/dist/index-") {
+			t.Errorf("Expected /static prefix with hash, got %s", path2)
+		}
+
+		// Test with root serving path
+		m3 := assets.NewManager(fstest.MapFS{
+			"vendor/@org/package-main@1.5.0/dist/index.js": {Data: []byte("// Main package")},
+		}, "/")
+
+		path3, err := m3.PathFor("vendor/@org/package-main@1.5.0/dist/index.js")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(path3, "/vendor/@org/package-main@1.5.0/dist/index-") {
+			t.Errorf("Expected root path with hash, got %s", path3)
+		}
+	})
+}
+
+func TestAllAssetsHashed(t *testing.T) {
+	t.Run("all file types are fingerprinted regardless of extension", func(t *testing.T) {
+		m := assets.NewManager(fstest.MapFS{
+			"main.js":          {Data: []byte("JS")},
+			"style.css":        {Data: []byte("CSS")},
+			"logo.svg":         {Data: []byte("SVG")},
+			"icon.svg":         {Data: []byte("SVG2")},
+			"favicon.ico":      {Data: []byte("ICO")},
+			"vendor/lib.js":    {Data: []byte("LIB")},
+			"vendor/helper.js": {Data: []byte("HELPER")},
+			"app/main.js":      {Data: []byte("MAIN")},
+		}, "/assets")
+
+		cases := []struct {
+			name   string
+			prefix string
+		}{
+			{"main.js", "/assets/main-"},
+			{"style.css", "/assets/style-"},
+			{"logo.svg", "/assets/logo-"},
+			{"icon.svg", "/assets/icon-"},
+			{"favicon.ico", "/assets/favicon-"},
+			{"vendor/lib.js", "/assets/vendor/lib-"},
+			{"vendor/helper.js", "/assets/vendor/helper-"},
+			{"app/main.js", "/assets/app/main-"},
+		}
+
+		for _, c := range cases {
+			got, err := m.PathFor(c.name)
+			if err != nil {
+				t.Fatalf("%s: %v", c.name, err)
+			}
+			if !strings.HasPrefix(got, c.prefix) {
+				t.Errorf("Expected %s to start with %s", got, c.prefix)
+			}
+		}
+	})
+
+	t.Run("Path method also hashes every asset", func(t *testing.T) {
+		m := assets.NewManager(fstest.MapFS{
+			"vendor.js": {Data: []byte("VENDOR")},
+			"logo.svg":  {Data: []byte("SVG")},
+		}, "/assets")
+
+		if got := m.Path("vendor.js"); !strings.Contains(got, "/vendor-") {
+			t.Errorf("Expected %s to be fingerprinted", got)
+		}
+
+		if got := m.Path("logo.svg"); !strings.Contains(got, "/logo-") {
+			t.Errorf("Expected %s to be fingerprinted", got)
 		}
 	})
 }

--- a/assets/importmap.go
+++ b/assets/importmap.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"path"
+	"strings"
 )
 
 func (m *manager) ImportMap() (template.HTML, error) {
@@ -21,13 +23,15 @@ func (m *manager) ImportMap() (template.HTML, error) {
 	defer f.Close()
 
 	var importMap struct {
-		Imports map[string]string `json:"imports"`
+		Imports map[string]string            `json:"imports"`
+		Scopes  map[string]map[string]string `json:"scopes,omitempty"`
 	}
 
 	if err := json.NewDecoder(f).Decode(&importMap); err != nil {
 		return "", err
 	}
 
+	// Process imports paths through fingerprinting
 	for k, v := range importMap.Imports {
 		hashed, err := m.PathFor(v)
 		if err != nil {
@@ -36,6 +40,32 @@ func (m *manager) ImportMap() (template.HTML, error) {
 		}
 
 		importMap.Imports[k] = hashed
+	}
+
+	// Process scopes: transform scope keys to include serving path and fingerprint values
+	if len(importMap.Scopes) > 0 {
+		transformedScopes := make(map[string]map[string]string)
+		
+		for scopeKey, scopeMap := range importMap.Scopes {
+			// Transform the scope key to include serving path prefix
+			// e.g., "vendor/@org/package@1.2.3/" -> "/assets/vendor/@org/package@1.2.3/"
+			transformedKey := m.addServingPath(scopeKey)
+			
+			transformedScopes[transformedKey] = make(map[string]string)
+			
+			// Process each scope value through fingerprinting
+			for k, v := range scopeMap {
+				hashed, err := m.PathFor(v)
+				if err != nil {
+					fmt.Printf("[error] error resolving scope path %q: %v\n", v, err)
+					continue
+				}
+
+				transformedScopes[transformedKey][k] = hashed
+			}
+		}
+		
+		importMap.Scopes = transformedScopes
 	}
 
 	b, err := json.MarshalIndent(importMap, "", "  ")
@@ -55,4 +85,15 @@ func (m *manager) ImportMap() (template.HTML, error) {
 	}
 
 	return template.HTML(buf.String()), nil
+}
+
+// addServingPath adds the serving path prefix to a scope key
+// e.g., "vendor/@org/package@1.2.3/" -> "/assets/vendor/@org/package@1.2.3/"
+func (m *manager) addServingPath(scopeKey string) string {
+	// Clean up the scope key
+	scopeKey = strings.TrimPrefix(scopeKey, "/")
+	scopeKey = strings.TrimSuffix(scopeKey, "/")
+	
+	// Add serving path prefix and trailing slash
+	return path.Join("/", m.servingPath, scopeKey) + "/"
 }


### PR DESCRIPTION
This PR makes the `core/assets` package fingerprint every assets, including entries inside scopes in the `importmap.json`. All assets now get a content hash for cache busting.